### PR TITLE
feat: allow dynamic product configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Hoặc sử dụng `node app.js` cho môi trường production.
     *   `activities` (Collection): Liên kết tới các hoạt động của người dùng này.
 
 *   **`Product`** (`api/models/Product.js`)
-    *   `name` (String): Tên sản phẩm.
-    *   `price` (Number): Giá sản phẩm.
-    *   `quantity` (Number): Số lượng tồn kho.
-    *   `tag` (String): Thẻ/danh mục của sản phẩm.
-    *   `owner` (Model): Liên kết tới model `User`, cho biết ai là người tạo ra sản phẩm.
+    *   `name` (String, optional): Tên sản phẩm.
+    *   `price` (Number, optional): Giá sản phẩm.
+    *   `quantity` (Number): Số lượng tồn kho (mặc định bằng `0`).
+    *   `tag` (String, optional): Thẻ/danh mục của sản phẩm.
+    *   `data` (JSON): Tập các trường động do người dùng cấu hình. Các khóa trong `data` được merge vào phản hồi API để thuận tiện truy cập.
 
 *   **`Activity`** (`api/models/Activity.js`)
     *   `type` (String): Loại hành động (ví dụ: `'CREATE'`, `'UPDATE'`, `'DELETE'`).
@@ -186,21 +186,23 @@ Tất cả các API đều yêu cầu `Authorization: Bearer <token>` trong head
     *   **Response (Success)**:
         ```json
         {
-          "products": [
-            { 
-              "id": "number", 
-              "name": "string", 
-              "price": "number", 
-              "quantity": "number", 
-              "tag": "string", 
-              "owner": "string" 
+          "message": "string",
+          "data": [
+            {
+              "id": "number",
+              "name": "string",
+              "price": "number",
+              "quantity": "number",
+              "tag": "string",
+              "data": { "customField": "any" },
+              "customField": "any"
             }
           ],
-          "pagination": { 
-            "page": "number", 
-            "limit": "number", 
-            "totalPages": "number", 
-            "totalProducts": "number" 
+          "pagination": {
+            "page": "number",
+            "limit": "number",
+            "totalPages": "number",
+            "totalItems": "number"
           }
         }
         ```
@@ -212,15 +214,18 @@ Tất cả các API đều yêu cầu `Authorization: Bearer <token>` trong head
         ```json
         {
           "products": [
-            { 
-              "name": "string", 
-              "price": "number", 
-              "quantity": "number", 
-              "tag": "string" 
+            {
+              "name": "string",
+              "price": "number",
+              "quantity": "number",
+              "tag": "string",
+              "data": { "sku": "string" },
+              "customField": "any"
             }
           ]
         }
         ```
+    *   **Ghi chú**: Các trường tùy chỉnh có thể được gửi trực tiếp (ví dụ `"customField"`) hoặc gói trong `data`. API sẽ lưu trữ toàn bộ và trả về các khóa đó ở cả cấp cao nhất lẫn trong `data`.
     *   **Response (Success)**:
         ```json
         {
@@ -236,12 +241,14 @@ Tất cả các API đều yêu cầu `Authorization: Bearer <token>` trong head
         ```json
         {
           "products": [
-            { 
-              "id": "number", 
-              "name": "string", 
-              "price": "number", 
-              "quantity": "number", 
-              "tag": "string" 
+            {
+              "id": "number",
+              "name": "string",
+              "price": "number",
+              "quantity": "number",
+              "tag": "string",
+              "data": { "sku": "string" },
+              "customField": "any"
             }
           ]
         }

--- a/backend/api/controllers/product/create-one.js
+++ b/backend/api/controllers/product/create-one.js
@@ -1,4 +1,7 @@
+const _ = require('@sailshq/lodash');
 
+const BASE_FIELDS = ['name', 'price', 'quantity', 'tag'];
+const RESERVED_FIELDS = ['id', 'createdAt', 'updatedAt'];
 
 module.exports = {
 
@@ -10,56 +13,94 @@ module.exports = {
     name: {
       description: 'The name of the product.',
       type: 'string',
-      required: true,
+      required: false,
     },
     price: {
       description: 'The price of the product.',
       type: 'number',
       required: false,
-      defaultsTo: 0
     },
     quantity: {
       description: 'The quantity of the product.',
       type: 'number',
       required: false,
-      defaultsTo: 0
     },
     tag: {
       description: 'The tag of the product.',
       type: 'string',
       required: false,
-    }
-    
+    },
+    data: {
+      description: 'Dynamic fields configured for the product.',
+      type: 'json',
+      required: false,
+      custom: (value) => _.isPlainObject(value),
+    },
+
   },
-  
+
   exits: {
     success: {
       description: 'OK.',
     },
+    badRequest: {
+      description: 'Invalid payload.',
+      responseType: 'badRequest',
+    },
   },
 
   fn: async function (inputs, exits) {
-    if(!inputs.name) {
-      return exits.badRequest({ message: 'Tên sản phẩm là bắt buộc.' });
+    const rawPayload = _.assign({}, inputs || {}, (this.req && this.req.body) || {});
+
+    const productPayload = {};
+
+    for (const field of BASE_FIELDS) {
+      if (!_.isUndefined(rawPayload[field])) {
+        const value = rawPayload[field];
+        const validator =
+          field === 'price' || field === 'quantity'
+            ? _.isNumber
+            : _.isString;
+
+        if (!validator(value)) {
+          return exits.badRequest({ message: `Trường ${field} không hợp lệ.` });
+        }
+
+        productPayload[field] = value;
+      }
     }
-    const done = await Product.create({
-      name: inputs.name,
-      price: inputs.price,
-      quantity: inputs.quantity || 0,
-      tag: inputs.tag || ''
-    }).fetch();
 
-    content = 'Đã tạo mới sản phẩm "' + done.name + '".';
+    if (!_.isUndefined(rawPayload.data) && !_.isPlainObject(rawPayload.data)) {
+      return exits.badRequest({ message: 'Dữ liệu cấu hình sản phẩm không hợp lệ.' });
+    }
 
+    const dynamicData = _.omit(rawPayload, [...BASE_FIELDS, 'data', ...RESERVED_FIELDS]);
+    const additionalData = _.isPlainObject(rawPayload.data) ? rawPayload.data : {};
 
-    if(done) {
+    const customData = _.assign({}, dynamicData, additionalData);
+
+    if (!_.isEmpty(customData)) {
+      productPayload.data = customData;
+    }
+
+    if (_.isEmpty(productPayload)) {
+      return exits.badRequest({ message: 'Không có dữ liệu sản phẩm hợp lệ.' });
+    }
+
+    const created = await Product.create(productPayload).fetch();
+    const done = created && _.isFunction(created.toJSON) ? created.toJSON() : created;
+
+    const content = done.name
+      ? `Đã tạo mới sản phẩm "${done.name}".`
+      : 'Đã tạo mới sản phẩm mới.';
+
+    if (done) {
       Activity.create({
         type: 'create',
-        content: content,
-        detail: done
-      })
-      .catch(err => {
-        console.log('Lỗi:', err);
+        content,
+        detail: done,
+      }).catch(err => {
+        sails.log.error('Lỗi:', err);
       });
     }
 

--- a/backend/api/controllers/product/create.js
+++ b/backend/api/controllers/product/create.js
@@ -1,4 +1,7 @@
+const _ = require('@sailshq/lodash');
 
+const BASE_FIELDS = ['name', 'price', 'quantity', 'tag'];
+const RESERVED_FIELDS = ['id', 'createdAt', 'updatedAt'];
 
 module.exports = {
 
@@ -7,7 +10,7 @@ module.exports = {
   description: 'Create a new product.',
 
   inputs: {
-    
+
     products: {
         description: 'An array of products to create.',
         required: true,
@@ -17,34 +20,83 @@ module.exports = {
             return false;
         }
         for (let product of value) {
-            if (!_.isObject(product) || 
-                !_.isString(product.name) || 
-                !_.isNumber(product.price) ||
-                !_.isNumber(product.quantity || 0) ||
-                (product.tag !== undefined && !_.isString(product.tag))) {
-            return false;
+            if (!_.isPlainObject(product)) {
+              return false;
             }
         }
         return true;
         }
     }
-    
+
   },
-  
+
   exits: {
     success: {
       description: 'OK.',
     },
+    badRequest: {
+      description: 'Invalid payload.',
+      responseType: 'badRequest',
+    }
   },
 
   fn: async function (inputs, exits) {
-    for (let product of inputs.products) {
-      product.id = undefined;
+    const sanitizedProducts = [];
+
+    let index = 0;
+    for (const rawProduct of inputs.products) {
+      index += 1;
+      if (!_.isPlainObject(rawProduct)) {
+        return exits.badRequest({ message: `Sản phẩm thứ ${index} không hợp lệ.` });
+      }
+
+      const productPayload = {};
+
+      for (const field of BASE_FIELDS) {
+        if (!_.isUndefined(rawProduct[field])) {
+          const value = rawProduct[field];
+          const validator =
+            field === 'price' || field === 'quantity'
+              ? _.isNumber
+              : _.isString;
+
+          if (!validator(value)) {
+            return exits.badRequest({ message: `Trường ${field} của sản phẩm thứ ${index} không hợp lệ.` });
+          }
+
+          productPayload[field] = value;
+        }
+      }
+
+      if (!_.isUndefined(rawProduct.data) && !_.isPlainObject(rawProduct.data)) {
+        return exits.badRequest({ message: `Dữ liệu cấu hình của sản phẩm thứ ${index} không hợp lệ.` });
+      }
+
+      const dynamicData = _.omit(rawProduct, [...BASE_FIELDS, 'data', ...RESERVED_FIELDS]);
+      const additionalData = _.isPlainObject(rawProduct.data) ? rawProduct.data : {};
+      const customData = _.assign({}, dynamicData, additionalData);
+
+      if (!_.isEmpty(customData)) {
+        productPayload.data = customData;
+      }
+
+      if (_.isEmpty(productPayload)) {
+        return exits.badRequest({ message: `Sản phẩm thứ ${index} không có dữ liệu hợp lệ.` });
+      }
+
+      sanitizedProducts.push(productPayload);
     }
-    const done = await Product.createEach(inputs.products).fetch();
+
+    const createdProducts = await Product.createEach(sanitizedProducts).fetch();
+    const done = createdProducts.map(product =>
+      _.isFunction(product.toJSON) ? product.toJSON() : product
+    );
+
     let content = `Đã tạo mới ${done.length} sản phẩm.`;
     if(done.length === 1) {
-      content = 'Đã tạo mới sản phẩm "' + done[0].name + '".';
+      content = done[0].name
+        ? `Đã tạo mới sản phẩm "${done[0].name}".`
+        : 'Đã tạo mới 1 sản phẩm.';
     }
     if(done.length > 0) {
       Activity.create({
@@ -53,7 +105,7 @@ module.exports = {
         detail: done
       })
       .catch(err => {
-        console.log('Lỗi:', err);
+        sails.log.error('Lỗi:', err);
       });
     }
 

--- a/backend/api/controllers/product/update-one.js
+++ b/backend/api/controllers/product/update-one.js
@@ -1,3 +1,7 @@
+const _ = require('@sailshq/lodash');
+
+const BASE_FIELDS = ['name', 'price', 'quantity', 'tag'];
+const RESERVED_FIELDS = ['id', 'createdAt', 'updatedAt'];
 
 module.exports = {
   friendlyName: 'Update',
@@ -27,6 +31,12 @@ module.exports = {
       description: 'The tag of the product.',
       type: 'string',
       required: false,
+    },
+    data: {
+      description: 'Dynamic fields configured for the product.',
+      type: 'json',
+      required: false,
+      custom: (value) => _.isPlainObject(value),
     }
   },
   exits: {
@@ -42,37 +52,72 @@ module.exports = {
     if (!inputs.id) {
       return exits.failed({ message: 'Product ID is required.' });
     }
-    const product = {
-      id: inputs.id,
-      name: inputs.name,
-      price: inputs.price,
-      quantity: inputs.quantity,
-      tag: inputs.tag
-    };
-    
 
-    
-    
-    const done = await Product.updateOne({ id: product.id }).set({
-      name: product.name,
-      price: product.price,
-      tag: product.tag,
-      quantity: product.quantity
-    });
+    const rawPayload = _.assign({}, inputs || {}, (this.req && this.req.body) || {});
 
-    content = `Đã cập nhật sản phẩm "${done.name}".`;
+    const existingProduct = await Product.findOne({ id: inputs.id });
+    if (!existingProduct) {
+      return exits.failed({ message: 'Product not found.' });
+    }
 
-    Activity.create({ 
+    const updatePayload = {};
+
+    for (const field of BASE_FIELDS) {
+      if (!_.isUndefined(rawPayload[field])) {
+        const value = rawPayload[field];
+        const validator =
+          field === 'price' || field === 'quantity'
+            ? _.isNumber
+            : _.isString;
+
+        if (!validator(value)) {
+          return exits.failed({ message: `Trường ${field} không hợp lệ.` });
+        }
+
+        updatePayload[field] = value;
+      }
+    }
+
+    if (!_.isUndefined(rawPayload.data) && !_.isPlainObject(rawPayload.data)) {
+      return exits.failed({ message: 'Dữ liệu cấu hình sản phẩm không hợp lệ.' });
+    }
+
+    const dynamicData = _.omit(rawPayload, [...BASE_FIELDS, 'data', ...RESERVED_FIELDS, 'id']);
+    const additionalData = _.isPlainObject(rawPayload.data) ? rawPayload.data : {};
+
+    let customData = _.assign({}, dynamicData, additionalData);
+
+    if (!_.isEmpty(customData)) {
+      const existingData = _.isPlainObject(existingProduct.data) ? existingProduct.data : {};
+      customData = _.assign({}, existingData, customData);
+      updatePayload.data = customData;
+    }
+
+    if (_.isEmpty(updatePayload)) {
+      return exits.failed({ message: 'Không có dữ liệu nào để cập nhật.' });
+    }
+
+    const updated = await Product.updateOne({ id: inputs.id }).set(updatePayload);
+
+    if (!updated) {
+      return exits.failed({ message: 'Product not found.' });
+    }
+
+    const done = _.isFunction(updated.toJSON) ? updated.toJSON() : updated;
+
+    const content = done.name
+      ? `Đã cập nhật sản phẩm "${done.name}".`
+      : `Đã cập nhật sản phẩm #${inputs.id}.`;
+
+    Activity.create({
       type: 'update',
       content: content,
       detail: done
     })
     .catch(err => {
-      console.log('Lỗi:', err);
+      sails.log.error('Lỗi:', err);
     });
-        
-
 
     return exits.success({ message: 'Update Product OK', finalProducts: done});
   }
-}
+};

--- a/backend/api/models/Product.js
+++ b/backend/api/models/Product.js
@@ -1,10 +1,27 @@
+const _ = require('@sailshq/lodash');
+
 module.exports = {
   attributes: {
-    name: { type: 'string', required: true },
-    price: { type: 'number'},
-    tag: { type: 'string' },
+    name: { type: 'string', allowNull: true },
+    price: { type: 'number', allowNull: true },
+    tag: { type: 'string', allowNull: true },
     quantity: { type: 'number', defaultsTo: 0 },
+    data: { type: 'json', columnType: 'object', defaultsTo: {} },
 
-    
+  },
+
+  customToJSON: function () {
+    const record = this;
+    const sanitizedRecord = _.omit(record, ['data']);
+
+    if (_.isPlainObject(record.data)) {
+      return {
+        ...sanitizedRecord,
+        ...record.data,
+        data: record.data,
+      };
+    }
+
+    return sanitizedRecord;
   },
 };

--- a/backend/test/integration/controllers/product/create.test.js
+++ b/backend/test/integration/controllers/product/create.test.js
@@ -8,11 +8,22 @@ describe('POST /api/product/create (Product Create)', () => {
     assert.ok(token, 'Missing global authToken.');
   });
 
-  it('should create multiple products and return them', async () => {
+  it('should create multiple products including custom fields', async () => {
     const payload = {
       products: [
-        { name: 'Socola Đen 70%', price: 20000, quantity: 10, tag: 'chocolate' },
-        { name: 'Trà Xanh Matcha', price: 15000, quantity: 5, tag: 'tea' },
+        {
+          name: 'Socola Đen 70%',
+          price: 20000,
+          quantity: 10,
+          tag: 'chocolate',
+          shelf: 'A1',
+          data: { sku: 'CH-70', flavour: 'Dark' },
+        },
+        {
+          label: 'Trà Xanh Matcha',
+          category: 'tea',
+          data: { sku: 'TR-01', origin: 'Japan' },
+        },
       ],
     };
 
@@ -25,8 +36,17 @@ describe('POST /api/product/create (Product Create)', () => {
     assert.strictEqual(res.body.message, 'Create Product OK');
     assert.ok(Array.isArray(res.body.products));
     assert.strictEqual(res.body.products.length, 2);
-    assert.ok(res.body.products[0].id, 'First product missing id');
-    assert.ok(res.body.products[1].id, 'Second product missing id');
+
+    const [firstProduct, secondProduct] = res.body.products;
+
+    assert.strictEqual(firstProduct.shelf, 'A1');
+    assert.strictEqual(firstProduct.data.sku, 'CH-70');
+    assert.strictEqual(firstProduct.data.flavour, 'Dark');
+
+    assert.ok(secondProduct.id, 'Second product missing id');
+    assert.strictEqual(secondProduct.label, 'Trà Xanh Matcha');
+    assert.strictEqual(secondProduct.data.origin, 'Japan');
+    assert.strictEqual(secondProduct.data.sku, 'TR-01');
   });
 
   it('should reject invalid payload (validation)', async () => {
@@ -55,6 +75,8 @@ describe('POST /api/product (Product Create-one)' , () => {
       price: 15000,
       quantity: 20,
       tag: 'bread',
+      data: { shelf: 'A2', calories: 250 },
+      supplier: 'Local Bakery',
     };
 
     const res = await request
@@ -64,13 +86,34 @@ describe('POST /api/product (Product Create-one)' , () => {
       .expect(200);
 
     assert.strictEqual(res.body.message, 'Create Product OK');
+    assert.strictEqual(res.body.products.data.shelf, 'A2');
+    assert.strictEqual(res.body.products.data.calories, 250);
+    assert.strictEqual(res.body.products.supplier, 'Local Bakery');
   });
 
-  it('missing name', async () => {
+  it('should allow creating product with only dynamic fields', async () => {
+    const payload = {
+      sku: 'SKU-123',
+      data: { color: 'red', size: 'M' },
+    };
+
+    const res = await request
+      .post('/api/product')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload)
+      .expect(200);
+
+    assert.strictEqual(res.body.message, 'Create Product OK');
+    assert.strictEqual(res.body.products.sku, 'SKU-123');
+    assert.strictEqual(res.body.products.data.color, 'red');
+    assert.strictEqual(res.body.products.data.size, 'M');
+  });
+
+  it('should reject empty payload', async () => {
     await request
       .post('/api/product')
       .set('Authorization', `Bearer ${token}`)
-      .send({ price: 10000 })
+      .send({})
       .expect(400);
   });
 

--- a/backend/test/unit/controllers/product/create-one.test.js
+++ b/backend/test/unit/controllers/product/create-one.test.js
@@ -2,36 +2,55 @@ const assert = require('assert');
 const createOne = require('../../../../api/controllers/product/create-one');
 describe('- product/create-one', () => {
     console.log("Running product/create-one tests...");
-    it("should success", async () => {
-        const mockInputs = {
+    it("should success with dynamic data", async () => {
+        const mockBody = {
             name: 'Test Product',
             price: 10000,
             quantity: 50,
-            tag: 'test'
+            tag: 'test',
+            data: { sku: 'SKU-001' },
+            shelf: 'A1'
         };
         const result = {};
         const exits = {
             success: (data) => { result.exit = 'success'; result.data = data; },
             badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
-        }
-        await createOne.fn(mockInputs, exits);
+        };
+        await createOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
 
         assert.strictEqual(result.exit, 'success', `Expected exit 'success' but got '${result.exit}'`);
         assert.ok(result.data.products, 'Missing products in response data');
-        assert.strictEqual(result.data.products.name, mockInputs.name, 'Product name mismatch');
-        assert.strictEqual(result.data.products.price, mockInputs.price, 'Product price mismatch');
-        assert.strictEqual(result.data.products.quantity, mockInputs.quantity, 'Product quantity mismatch');
-        assert.strictEqual(result.data.products.tag, mockInputs.tag, 'Product tag mismatch');
-    
+        assert.strictEqual(result.data.products.name, mockBody.name, 'Product name mismatch');
+        assert.strictEqual(result.data.products.price, mockBody.price, 'Product price mismatch');
+        assert.strictEqual(result.data.products.quantity, mockBody.quantity, 'Product quantity mismatch');
+        assert.strictEqual(result.data.products.tag, mockBody.tag, 'Product tag mismatch');
+        assert.strictEqual(result.data.products.shelf, mockBody.shelf, 'Custom field mismatch');
+        assert.strictEqual(result.data.products.data.sku, mockBody.data.sku, 'Custom data mismatch');
+
         await Product.destroy({ });
     });
 
-    it("should fail on missing fields", async () => {
-        const mockInputs = {
-            name: '',
-            price: null,
-            quantity: null,
-            tag: ''
+    it("should fail on empty payload", async () => {
+        const mockBody = {};
+
+        const result = {};
+
+        const exits = {
+            success: (data) => { result.exit = 'success'; result.data = data; },
+            badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
+        };
+
+        await createOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
+
+        assert.strictEqual(result.exit, 'badRequest', `Expected exit 'badRequest' but got '${result.exit}'`);
+
+        await Product.destroy({ });
+    });
+
+    it("should fail on invalid price", async () => {
+        const mockBody = {
+            name: 'Invalid price',
+            price: 'abc'
         };
 
         const result = {};
@@ -39,12 +58,12 @@ describe('- product/create-one', () => {
         const exits = {
             success: (data) => { result.exit = 'success'; result.data = data; },
             badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
-        }
+        };
 
-        await createOne.fn(mockInputs, exits);
+        await createOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
 
         assert.strictEqual(result.exit, 'badRequest', `Expected exit 'badRequest' but got '${result.exit}'`);
-        
+
         await Product.destroy({ });
     });
 });

--- a/backend/test/unit/controllers/product/update-one.test.js
+++ b/backend/test/unit/controllers/product/update-one.test.js
@@ -7,39 +7,45 @@ describe('- product/update-one', () => {
             name: 'Initial Product',
             price: 5000,
             quantity: 30,
-            tag: 'initial'
+            tag: 'initial',
+            data: { sku: 'SKU-INIT' },
+            shelf: 'A1'
         }).fetch();
 
-        const mockInputs = {
+        const mockBody = {
             id: createdProduct.id,
             name: 'Updated Product',
             price: 8000,
             quantity: 25,
-            tag: 'updated'
+            tag: 'updated',
+            data: { sku: 'SKU-UPDATED' },
+            shelf: 'B2'
         };
 
         const result = {};
 
         const exits = {
             success: (data) => { result.exit = 'success'; result.data = data; },
-            notFound: (data) => { result.exit = 'notFound'; result.data = data; },
+            failed: (data) => { result.exit = 'failed'; result.data = data; },
             badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
-        }
+        };
 
-        await updateOne.fn(mockInputs, exits);
+        await updateOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
 
         assert.strictEqual(result.exit, 'success', `Expected exit 'success' but got '${result.exit}'`);
         assert.ok(result.data.finalProducts, 'Missing products in response data');
-        assert.strictEqual(result.data.finalProducts.name, mockInputs.name, 'Product name mismatch');
-        assert.strictEqual(result.data.finalProducts.price, mockInputs.price, 'Product price mismatch');
-        assert.strictEqual(result.data.finalProducts.quantity, mockInputs.quantity, 'Product quantity mismatch');
-        assert.strictEqual(result.data.finalProducts.tag, mockInputs.tag, 'Product tag mismatch');
-        
+        assert.strictEqual(result.data.finalProducts.name, mockBody.name, 'Product name mismatch');
+        assert.strictEqual(result.data.finalProducts.price, mockBody.price, 'Product price mismatch');
+        assert.strictEqual(result.data.finalProducts.quantity, mockBody.quantity, 'Product quantity mismatch');
+        assert.strictEqual(result.data.finalProducts.tag, mockBody.tag, 'Product tag mismatch');
+        assert.strictEqual(result.data.finalProducts.shelf, mockBody.shelf, 'Custom field mismatch');
+        assert.strictEqual(result.data.finalProducts.data.sku, mockBody.data.sku, 'Custom data mismatch');
+
         await Product.destroy({ });
     });
 
     it("should fail on missing id", async () => {
-        const mockInputs = {
+        const mockBody = {
             name: 'Product',
             price: 8000,
             quantity: 25,
@@ -52,13 +58,40 @@ describe('- product/update-one', () => {
             success: (data) => { result.exit = 'success'; result.data = data; },
             failed: (data) => { result.exit = 'failed'; result.data = data; },
             badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
-        }
+        };
 
-        await updateOne.fn(mockInputs, exits);
+        await updateOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
 
         assert.strictEqual(result.exit, 'failed', `Expected exit 'failed' but got '${result.exit}'`);
-        
+
         await Product.destroy({ });
     });
-    
+
+    it("should fail on invalid price", async () => {
+        const createdProduct = await Product.create({
+            name: 'Initial Product',
+            price: 5000,
+            quantity: 30,
+            tag: 'initial'
+        }).fetch();
+
+        const mockBody = {
+            id: createdProduct.id,
+            price: 'invalid'
+        };
+
+        const result = {};
+
+        const exits = {
+            success: (data) => { result.exit = 'success'; result.data = data; },
+            failed: (data) => { result.exit = 'failed'; result.data = data; },
+            badRequest: (data) => { result.exit = 'badRequest'; result.data = data; }
+        };
+
+        await updateOne.fn.call({ req: { body: mockBody } }, mockBody, exits);
+
+        assert.strictEqual(result.exit, 'failed', `Expected exit 'failed' but got '${result.exit}'`);
+
+        await Product.destroy({ });
+    });
 });


### PR DESCRIPTION
## Summary
- allow the product model to store user-defined fields in a json payload that is merged into api responses
- update create and update flows to accept dynamic payloads and keep activity logs in sync
- refresh documentation and tests to cover configurable product data

## Testing
- npm run test:i
- npm run test:u

------
https://chatgpt.com/codex/tasks/task_e_68c8cea489e08326a11b5a83713a597b